### PR TITLE
Changed addresses to uppercase.

### DIFF
--- a/lib/64core/kernal.asm
+++ b/lib/64core/kernal.asm
@@ -18,10 +18,10 @@
   .label clrchn = $FFCC
   .label load = $FFD5
   .label save = $FFD8
-  .label restor = $ff8a
-  .label plot = $fff0
-  .label clear_screen = $e544
-  .label chrout_screen = $e716
+  .label restor = $FF8A
+  .label plot = $FFF0
+  .label clear_screen = $E544
+  .label chrout_screen = $E716
 } 
 
 .pseudocommand kernal_plot_get column: row {


### PR DESCRIPTION
I'm a huge fan of using uppercase for representing hexadecimal numbers.  Plus, I noticed that most of the other addresses in the namespace were uppercase.  So I propose to make them all consistent.